### PR TITLE
MAX4 macro

### DIFF
--- a/src/alignment.c
+++ b/src/alignment.c
@@ -24,15 +24,6 @@ const char align_col_indel[] = "\033[91m"; // Insertion / deletion (RED)
 const char align_col_context[] = "\033[95m";
 const char align_col_stop[] = "\033[0m";
 
-static long max4(long a, long b, long c, long d)
-{
-  long result = a;
-  if(b > result) result = b;
-  if(c > result) result = c;
-  if(d > result) result = d;
-  return result;
-}
-
 // Fill in traceback matrix
 static void alignment_fill_matrices(aligner_t *aligner, char is_sw)
 {
@@ -123,7 +114,7 @@ static void alignment_fill_matrices(aligner_t *aligner, char is_sw)
         // 2) close gap in seq_a
         // 3) close gap in seq_b
         match_scores[index]
-          = max4(match_scores[index_upleft] + substitution_penalty,
+          = MAX4(match_scores[index_upleft] + substitution_penalty,
                  gap_a_scores[index_upleft] + substitution_penalty,
                  gap_b_scores[index_upleft] + substitution_penalty,
                  min);
@@ -142,7 +133,7 @@ static void alignment_fill_matrices(aligner_t *aligner, char is_sw)
       else if(!scoring->no_gaps_in_a || seq_i == len_i-1)
       {
         gap_a_scores[index]
-          = max4(match_scores[index_up] + gap_open_penalty,
+          = MAX4(match_scores[index_up] + gap_open_penalty,
                  gap_a_scores[index_up] + gap_extend_penalty,
                  gap_b_scores[index_up] + gap_open_penalty,
                  min);
@@ -160,7 +151,7 @@ static void alignment_fill_matrices(aligner_t *aligner, char is_sw)
       else if(!scoring->no_gaps_in_b || seq_j == len_j-1)
       {
         gap_b_scores[index]
-          = max4(match_scores[index_left] + gap_open_penalty,
+          = MAX4(match_scores[index_left] + gap_open_penalty,
                  gap_a_scores[index_left] + gap_open_penalty,
                  gap_b_scores[index_left] + gap_extend_penalty,
                  min);

--- a/src/alignment_macros.h
+++ b/src/alignment_macros.h
@@ -19,6 +19,7 @@
 #define MIN2(x,y) ((x) <= (y) ? (x) : (y))
 #define MAX3(x,y,z) ((x) >= (y) && (x) >= (z) ? (x) : MAX2(y,z))
 #define MIN3(x,y,z) ((x) <= (y) && (x) <= (z) ? (x) : MIN2(y,z))
+#define MAX4(w,x,y,z) MAX2(MAX3(w, x, y), z)
 
 #define ABSDIFF(a,b) ((a) > (b) ? (a)-(b) : (b)-(a))
 


### PR DESCRIPTION
The `max4` function appears to take a large amount of time for a simple operation.  With an input file containing 6,596 alignments, running:

`time ./bin/needleman_wunsch --file test.fasta --wildcard N 1 --printfasta`

Gives:

`43.66s user 0.01s system 99% cpu 43.668 total`

Gprof shows:
```
  %   cumulative   self              self     total           
 time   seconds   seconds    calls   s/call   s/call  name    
 45.31     12.70    12.70     6596     0.00     0.00  alignment_fill_matrices
 22.41     18.98     6.28 2617031170     0.00     0.00  max4
 19.45     24.43     5.45 876113280     0.00     0.00  scoring_lookup
 10.06     27.25     2.82 876113280     0.00     0.00  _scoring_check_wildcards
  1.96     27.80     0.55        1     0.55    27.88  align_from_file
  0.50     27.94     0.14        1     0.14     0.14  scoring_add_wildcard
  0.25     28.01     0.07  2134272     0.00     0.00  alignment_reverse_move
...
```

So a bit under half the total time is spent in that function.  After this change the same command gives:

`26.39s user 0.01s system 99% cpu 26.408 total`